### PR TITLE
Final improvements for Carbonado 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "carbonado"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = "An apocalypse-resistant data storage format for the truly paranoid."

--- a/README.md
+++ b/README.md
@@ -93,3 +93,11 @@ The values 4/8 were chosen for Zfec's k of m parameters, meaning, only 4 valid c
 Bao only supports a fixed chunk size of 1KB, so the smallest a Carbonado file can be is 8KB. This also aligns well with 4KB HDD sectors, for less wasted space.
 
 Storage providers will not need to use RAID to protect storage volumes so long as `carbonadod` is configured to store archive chunks on 8 separate storage volumes. In case a volume fails, scrubbing will recover the missing data. When data is served, only 4 of the chunks are needed. This results in a sort of user-level "application RAID", which is inline with Carbonado's design principles of being a flexible format with user-friendly configuration options. It's designed to be as approachable for "Uncle Jim" hobbyists to use as it is for professional mining datacenters bagged in FIL or XCH.
+
+## Terminology
+
+Files are split into segments of a maximum of 1MB input length. This was chosen because it aligns well with the IPFS IPLD, Storm, and BitTorrent frontends. These segments are tracked and combined separately using catalog files, which may also store additional metadata about the files needed for specific storage frontends. Chunks are used for error correction, and can be stored separately on separate volumes. Slices are relevant to stream verification, are hardcoded to be 1KB in size, and are also a reference to Rust byte slices (references to an array of unsighted 8-bit integers).
+
+In summary: File of n MB -> n MB / 1MB Catalog Segments -> 8x Zfec Chunks -> >=16MB / 8x / 1024 Byte Slices
+
+Only chunks are stored separately on-disk. Slices are referenced in-memory, and how segments are streamed is frontend-specific. Segmentation also helps with computational parallelization, reduces node memory requirements, and helps spread IO load across storage volumes.

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -1,6 +1,6 @@
 use std::io::Write;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use bao::{encode::encode as bao_encode, Hash};
 use ecies::encrypt;
 use log::debug;
@@ -42,8 +42,8 @@ pub fn bao(input: &[u8]) -> Result<(Vec<u8>, Hash)> {
 /// Returns a tuple of encoded bytes, the amount of padding used, and the length of each chunk.
 pub fn zfec(input: &[u8]) -> Result<(Vec<u8>, u32, u32)> {
     let input_len = input.len();
-    let (padding_len, chunk_size) = calc_padding_len(input_len);
-    // TODO: CSPRNG padding
+    let (padding_len, chunk_len) = calc_padding_len(input_len);
+
     let mut padding_bytes = vec![0u8; padding_len as usize];
     let mut padded_input = Vec::from(input);
     padded_input.append(&mut padding_bytes);
@@ -55,24 +55,22 @@ pub fn zfec(input: &[u8]) -> Result<(Vec<u8>, u32, u32)> {
     let fec = Fec::new(FEC_K, FEC_M)?;
     let (mut encoded_chunks, zfec_padding) = fec.encode(&padded_input)?;
 
-    assert_eq!(
-        zfec_padding, 0,
-        "Padding from Zfec should always be zero, since Carbonado adds its own padding. Padding was: {zfec_padding}"
-    );
+    if zfec_padding != 0 {
+        return Err(anyhow!(
+        "Padding from Zfec should always be zero, since Carbonado adds its own padding. Padding was {zfec_padding}."
+    ));
+    }
 
     let mut encoded = vec![];
 
     for chunk in &mut encoded_chunks {
-        assert_eq!(
-            chunk_size,
-            chunk.data.len() as u32,
-            "Chunk size should be as calculated"
-        );
-        log::debug!("Hello, CHUNK INDEX: {}", chunk.index);
+        if chunk_len != chunk.data.len() as u32 {
+            return Err(anyhow!("Chunk length should be as calculated. Calculated chunk length was {chunk_len}, but actual chunk length was {}", chunk.data.len()));
+        }
         encoded.append(&mut chunk.data);
     }
 
-    Ok((encoded, padding_len, chunk_size))
+    Ok((encoded, padding_len, chunk_len))
 }
 
 /// Encode data into Carbonado format in this order:
@@ -87,9 +85,10 @@ pub fn encode(pubkey: &[u8], input: &[u8], format: u8) -> Result<(Vec<u8>, Hash,
     let compressed;
     let encrypted;
     let encoded;
-    let padding;
-    let chunk_size;
-    let slice_count;
+    let padding_len;
+    let chunk_len;
+    let verifiable_slice_count;
+    let chunk_slice_count;
     let verifiable;
     let hash;
 
@@ -115,15 +114,23 @@ pub fn encode(pubkey: &[u8], input: &[u8], format: u8) -> Result<(Vec<u8>, Hash,
     }
 
     if format.contains(Format::Zfec) {
-        (encoded, padding, chunk_size) = zfec(&encrypted)?;
+        (encoded, padding_len, chunk_len) = zfec(&encrypted)?;
         bytes_ecc = encoded.len() as u32;
-        slice_count = (bytes_ecc / SLICE_LEN as u32) as u16;
+        verifiable_slice_count = (bytes_ecc / SLICE_LEN as u32) as u16;
+        if verifiable_slice_count % 8 != 0 {
+            return Err(anyhow!(
+                "Verifiable slice count should be evenly divisible by 8. Remainder was {}.",
+                verifiable_slice_count % 8
+            ));
+        }
+        chunk_slice_count = verifiable_slice_count / 8;
     } else {
         encoded = encrypted;
-        padding = 0;
-        chunk_size = 0;
+        padding_len = 0;
+        chunk_len = 0;
         bytes_ecc = 0;
-        slice_count = 0;
+        verifiable_slice_count = 0;
+        chunk_slice_count = 0;
     }
 
     if format.contains(Format::Bao) {
@@ -150,9 +157,10 @@ pub fn encode(pubkey: &[u8], input: &[u8], format: u8) -> Result<(Vec<u8>, Hash,
             bytes_verifiable,
             compression_factor,
             amplification_factor,
-            padding,
-            chunk_size,
-            slice_count,
+            padding_len,
+            chunk_len,
+            verifiable_slice_count,
+            chunk_slice_count,
         },
     ))
 }

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -21,9 +21,11 @@ pub struct EncodeInfo {
     /// The total amount of file amplification. 2.0x is typical for 4/8 Zfec encoding, the others are pretty minimal, at roughly 1.1x.
     pub amplification_factor: f32,
     /// The amount of padding added to input data in order to align it with Bao slice size (1KB) and 4/8 Zfec chunk size (4KB).
-    pub padding: u32,
+    pub padding_len: u32,
     /// How many bytes are in each Zfec chunk
-    pub chunk_size: u32,
+    pub chunk_len: u32,
     /// How many slices are there, total
-    pub slice_count: u16,
+    pub verifiable_slice_count: u16,
+    /// How many slices there are per chunk
+    pub chunk_slice_count: u16,
 }

--- a/tests/apocalypse.rs
+++ b/tests/apocalypse.rs
@@ -70,8 +70,7 @@ fn act_of_god(path: &str) -> Result<()> {
     info!("Encoding {path}...");
     let (orig_encoded, hash, encode_info) = encode(&pk.serialize(), &input, 12)?;
     debug!("Encoding Info: {encode_info:#?}");
-    let mut new_encoded = Vec::new();
-    new_encoded.clone_from(&orig_encoded);
+    let mut new_encoded = orig_encoded.clone();
 
     info!("Scrubbing stream against hash: {hash}...");
     let orig_result = scrub(&orig_encoded, hash.as_bytes(), &encode_info);

--- a/tests/codec.rs
+++ b/tests/codec.rs
@@ -78,14 +78,14 @@ fn codec(path: &str) -> Result<()> {
     );
 
     info!("Verifying stream against hash: {hash}...");
-    verify_slice(&hash, &encoded, 0, encode_info.slice_count)?;
+    verify_slice(&hash, &encoded, 0, encode_info.verifiable_slice_count)?;
 
     info!("Decoding Carbonado bytes");
     let decoded = decode(
         &sk.serialize(),
         hash.as_bytes(),
         &encoded,
-        encode_info.padding,
+        encode_info.padding_len,
         15,
     )?;
     assert_eq!(decoded, input, "Decoded output is same as encoded input");

--- a/tests/format.rs
+++ b/tests/format.rs
@@ -31,12 +31,13 @@ fn format() -> Result<()> {
         &sk.serialize(),
         hash.as_bytes(),
         format,
+        0,
         encode_info.bytes_verifiable,
-        encode_info.padding,
+        encode_info.padding_len,
     )?;
     trace!("Header: {header:#?}");
 
-    let header_bytes = header.to_vec();
+    let header_bytes = header.try_to_vec()?;
 
     let file_path = PathBuf::from("/tmp").join(header.filename());
     info!("Writing test file to: {file_path:?}");
@@ -58,15 +59,16 @@ fn format() -> Result<()> {
     );
     assert_eq!(header.hash, hash);
     assert_eq!(header.format, format);
+    assert_eq!(header.chunk_index, 0);
     assert_eq!(header.encoded_len, encode_info.bytes_verifiable);
-    assert_eq!(header.padding_len, encode_info.padding);
+    assert_eq!(header.padding_len, encode_info.padding_len);
 
     info!("Decoding Carbonado bytes");
     let decoded = decode(
         &sk.serialize(),
         hash.as_bytes(),
         &encoded,
-        encode_info.padding,
+        encode_info.padding_len,
         15,
     )?;
 


### PR DESCRIPTION
CSPRNG padding is not necessary due to the padding 0s not being a part of the ciphertext.
Improve terminology disambiguation in README and EncodeInfo struct.
Replace runtime assertions with non-panicking error handling.