### PR TITLE
Fixes for use in Carbonado Node

### DIFF
--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -9,7 +9,7 @@ use zfec_rs::Fec;
 
 use crate::{
     constants::{Format, FEC_K, FEC_M, SLICE_LEN},
-    structs::EncodeInfo,
+    structs::{EncodeInfo, Encoded},
     utils::calc_padding_len,
 };
 
@@ -76,7 +76,7 @@ pub fn zfec(input: &[u8]) -> Result<(Vec<u8>, u32, u32)> {
 /// Encode data into Carbonado format, performing compression, encryption, adding error correction codes, and stream verification encoding, in that order.
 ///
 ///  `snap -> ecies -> zfec -> bao`
-pub fn encode(pubkey: &[u8], input: &[u8], format: u8) -> Result<(Vec<u8>, Hash, EncodeInfo)> {
+pub fn encode(pubkey: &[u8], input: &[u8], format: u8) -> Result<Encoded> {
     let input_len = input.len() as u32;
     let format = Format::try_from(format)?;
 
@@ -145,7 +145,7 @@ pub fn encode(pubkey: &[u8], input: &[u8], format: u8) -> Result<(Vec<u8>, Hash,
     let amplification_factor = bytes_verifiable as f32 / input_len as f32;
     let output_len = verifiable.len() as u32;
 
-    Ok((
+    Ok(Encoded(
         verifiable,
         hash,
         EncodeInfo {

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -70,8 +70,14 @@ impl TryFrom<File> for Header {
         }
 
         let pubkey = PublicKey::from_slice(&pubkey)?;
-        let hash = bao::Hash::try_from(hash)?;
         let signature = Signature::from_slice(&signature)?;
+
+        // Verify hash against signature
+        let (x_only_pk, _) = pubkey.x_only_public_key();
+        signature.verify(&Message::from_slice(&hash)?, &x_only_pk)?;
+
+        let hash = bao::Hash::try_from(hash)?;
+
         let format = Format::try_from(format[0])?;
         let chunk_index = u8::from_le_bytes(chunk_index);
         let encoded_len = u32::from_le_bytes(encoded_len);

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -34,3 +34,7 @@ pub struct EncodeInfo {
     /// How many slices there are per chunk.
     pub chunk_slice_count: u16,
 }
+
+/// Tuple of verifiable bytes, bao hash, and encode info struct
+/// i.e., Encoded(encoded_bytes, bao_hash, encode_info)
+pub struct Encoded(pub Vec<u8>, pub bao::Hash, pub EncodeInfo);

--- a/tests/apocalypse.rs
+++ b/tests/apocalypse.rs
@@ -1,7 +1,7 @@
 use std::fs::read;
 
 use anyhow::Result;
-use carbonado::{encode, scrub, utils::init_logging};
+use carbonado::{encode, scrub, structs::Encoded, utils::init_logging};
 use ecies::utils::generate_keypair;
 use log::{debug, info};
 use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
@@ -68,7 +68,7 @@ fn act_of_god(path: &str) -> Result<()> {
     let input = read(path)?;
     let (_sk, pk) = generate_keypair();
     info!("Encoding {path}...");
-    let (orig_encoded, hash, encode_info) = encode(&pk.serialize(), &input, 12)?;
+    let Encoded(orig_encoded, hash, encode_info) = encode(&pk.serialize(), &input, 12)?;
     debug!("Encoding Info: {encode_info:#?}");
     let mut new_encoded = orig_encoded.clone();
 

--- a/tests/codec.rs
+++ b/tests/codec.rs
@@ -1,7 +1,7 @@
 use std::fs::read;
 
 use anyhow::Result;
-use carbonado::{decode, encode, utils::init_logging, verify_slice};
+use carbonado::{decode, encode, structs::Encoded, utils::init_logging, verify_slice};
 use ecies::utils::generate_keypair;
 use log::{debug, info};
 use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
@@ -68,7 +68,7 @@ fn codec(path: &str) -> Result<()> {
     let (sk, pk) = generate_keypair();
 
     info!("Encoding {path}...");
-    let (encoded, hash, encode_info) = encode(&pk.serialize(), &input, 15)?;
+    let Encoded(encoded, hash, encode_info) = encode(&pk.serialize(), &input, 15)?;
 
     debug!("Encoding Info: {encode_info:#?}");
     assert_eq!(

--- a/tests/format.rs
+++ b/tests/format.rs
@@ -1,7 +1,9 @@
 use std::{fs::OpenOptions, io::Write, path::PathBuf};
 
 use anyhow::Result;
-use carbonado::{constants::Format, decode, encode, fs::Header, utils::init_logging};
+use carbonado::{
+    constants::Format, decode, encode, fs::Header, structs::Encoded, utils::init_logging,
+};
 use ecies::utils::generate_keypair;
 use log::{debug, info, trace};
 use secp256k1::PublicKey;
@@ -19,7 +21,7 @@ fn format() -> Result<()> {
     let format = Format::try_from(carbonado_level)?;
 
     info!("Encoding input: {input:?}...");
-    let (encoded, hash, encode_info) = encode(&pk.serialize(), input, carbonado_level)?;
+    let Encoded(encoded, hash, encode_info) = encode(&pk.serialize(), input, carbonado_level)?;
 
     debug!("Encoding Info: {encode_info:#?}");
 


### PR DESCRIPTION
- [x] Define result of encode as Encoded struct. 
- [x] Verify hash signatures in Header::try_from.