### PR TITLE
Header parsing file reference

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "carbonado"
-version = "0.3.0-rc.7"
+version = "0.3.0-rc.8"
 edition = "2021"
 license = "MIT"
 description = "An apocalypse-resistant data storage format for the truly paranoid."

--- a/src/file.rs
+++ b/src/file.rs
@@ -39,11 +39,11 @@ pub struct Header {
     pub padding_len: u32,
 }
 
-impl TryFrom<File> for Header {
+impl TryFrom<&File> for Header {
     type Error = Error;
 
     /// Attempts to decode a header from a file.
-    fn try_from(mut file: File) -> Result<Self> {
+    fn try_from(mut file: &File) -> Result<Self> {
         let mut magic_no = [0_u8; 12];
         let mut pubkey = [0_u8; 33];
         let mut hash = [0_u8; 32];

--- a/tests/format.rs
+++ b/tests/format.rs
@@ -68,7 +68,7 @@ fn format() -> Result<()> {
     info!("Test file successfully written.");
 
     info!("Parsing file headers...");
-    let header = Header::try_from(file)?;
+    let header = Header::try_from(&file)?;
 
     assert_eq!(header.pubkey, PublicKey::from_slice(&pk.serialize())?);
     assert_eq!(header.hash, hash);


### PR DESCRIPTION
A &File reference is provided to the try_from method for Header parsing.