### PR TITLE
Metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "carbonado"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "MIT"
 description = "An apocalypse-resistant data storage format for the truly paranoid."

--- a/tests/format.rs
+++ b/tests/format.rs
@@ -51,6 +51,7 @@ fn format() -> Result<()> {
         0,
         encode_info.bytes_verifiable,
         encode_info.padding_len,
+        None,
     )?;
     trace!("Header: {header:#?}");
 


### PR DESCRIPTION
Adds the capability to store 8 extra bytes as metadata. These were originally just used as extra padding bytes to make the length an even 160 bytes.